### PR TITLE
Using JUnit assert functions instead of assert keyword in unit tests,

### DIFF
--- a/src/test/java/com/seventhtill/item/armour/ArmourCompositeTest.java
+++ b/src/test/java/com/seventhtill/item/armour/ArmourCompositeTest.java
@@ -23,7 +23,7 @@ class ArmourCompositeTest {
 
         int actualValue = testArmourComposite.getArmourClassModifier(testDexModifier);
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -32,7 +32,7 @@ class ArmourCompositeTest {
 
         int actualValue = testArmourComposite.getBaseArmour();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -41,7 +41,7 @@ class ArmourCompositeTest {
 
         boolean actualValue = testArmourComposite.isDisadvantage();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -50,6 +50,6 @@ class ArmourCompositeTest {
 
         int actualValue = testArmourComposite.getWeight();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 }

--- a/src/test/java/com/seventhtill/item/armour/HeavyArmourTest.java
+++ b/src/test/java/com/seventhtill/item/armour/HeavyArmourTest.java
@@ -15,7 +15,7 @@ class HeavyArmourTest {
 
         int actualValue = testArmour.getArmourClassModifier(testDexModifier);
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -27,7 +27,7 @@ class HeavyArmourTest {
 
         int actualValue = testArmour.getBaseArmour();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -38,7 +38,7 @@ class HeavyArmourTest {
 
         boolean actualValue = testArmour.isDisadvantage();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -49,7 +49,7 @@ class HeavyArmourTest {
 
         int actualValue = testArmour.getWeight();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -60,6 +60,6 @@ class HeavyArmourTest {
 
         String actualValue = testArmour.getName();
 
-        assert expectedValue.equals(actualValue);
+        assertEquals(actualValue, expectedValue);
     }
 }

--- a/src/test/java/com/seventhtill/item/armour/LightArmourTest.java
+++ b/src/test/java/com/seventhtill/item/armour/LightArmourTest.java
@@ -15,7 +15,7 @@ class LightArmourTest {
 
         int actualValue = testArmour.getArmourClassModifier(testDexModifier);
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -27,7 +27,7 @@ class LightArmourTest {
 
         int actualValue = testArmour.getBaseArmour();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -38,7 +38,7 @@ class LightArmourTest {
 
         boolean actualValue = testArmour.isDisadvantage();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -49,7 +49,7 @@ class LightArmourTest {
 
         int actualValue = testArmour.getWeight();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -60,6 +60,6 @@ class LightArmourTest {
 
         String actualValue = testArmour.getName();
 
-        assert expectedValue.equals(actualValue);
+        assertEquals(actualValue, expectedValue);
     }
 }

--- a/src/test/java/com/seventhtill/item/armour/MediumArmourTest.java
+++ b/src/test/java/com/seventhtill/item/armour/MediumArmourTest.java
@@ -16,7 +16,7 @@ class MediumArmourTest {
 
         int actualValue = testArmour.getArmourClassModifier(testDexModifier);
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -29,7 +29,7 @@ class MediumArmourTest {
 
         int actualValue = testArmour.getArmourClassModifier(testDexModifier);
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -41,7 +41,7 @@ class MediumArmourTest {
 
         int actualValue = testArmour.getBaseArmour();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -52,7 +52,7 @@ class MediumArmourTest {
 
         boolean actualValue = testArmour.isDisadvantage();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -63,7 +63,7 @@ class MediumArmourTest {
 
         int actualValue = testArmour.getWeight();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -74,6 +74,6 @@ class MediumArmourTest {
 
         String actualValue = testArmour.getName();
 
-        assert expectedValue.equals(actualValue);
+        assertEquals(actualValue, expectedValue);
     }
 }

--- a/src/test/java/com/seventhtill/item/armour/ShieldTest.java
+++ b/src/test/java/com/seventhtill/item/armour/ShieldTest.java
@@ -14,7 +14,7 @@ class ShieldTest {
 
         int actualValue = testShield.getArmourClassModifier(0);
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -25,7 +25,7 @@ class ShieldTest {
 
         int actualValue = testShield.getBaseArmour();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -36,7 +36,7 @@ class ShieldTest {
 
         boolean actualValue = testShield.isDisadvantage();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -47,7 +47,7 @@ class ShieldTest {
 
         int actualValue = testShield.getWeight();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -58,6 +58,6 @@ class ShieldTest {
 
         String actualValue = testShield.getName();
 
-        assert expectedValue.equals(actualValue);
+        assertEquals(actualValue, expectedValue);
     }
 }

--- a/src/test/java/com/seventhtill/item/weapon/MartialWeaponTest.java
+++ b/src/test/java/com/seventhtill/item/weapon/MartialWeaponTest.java
@@ -19,7 +19,7 @@ class MartialWeaponTest {
 
         String actualName = testWeapon.getName();
 
-        assert expectedName.equals(actualName);
+        assertEquals(actualName, expectedName);
     }
 
     @Test
@@ -31,7 +31,7 @@ class MartialWeaponTest {
 
         int actualWeight = testWeapon.getWeight();
 
-        assert expectedWeight == actualWeight;
+        assertEquals(expectedWeight, actualWeight);
     }
 
     @Test
@@ -45,8 +45,8 @@ class MartialWeaponTest {
 
         List<String> actualProperties = testWeapon.getProperties();
 
-        assert expectedProperties.equals(actualProperties);
-        assert expectedProperties != actualProperties;
+        assertEquals(actualProperties, expectedProperties);
+        assertNotSame(expectedProperties, actualProperties);
 
     }
 
@@ -60,7 +60,7 @@ class MartialWeaponTest {
         testWeapon.setName(expectedName);
         String actualName = testWeapon.getName();
 
-        assert expectedName.equals(actualName);
+        assertEquals(actualName, expectedName);
     }
 
     @Test
@@ -73,6 +73,6 @@ class MartialWeaponTest {
         testWeapon.setWeight(expectedWeight);
         int actualWeight = testWeapon.getWeight();
 
-        assert expectedWeight == actualWeight;
+        assertEquals(expectedWeight, actualWeight);
     }
 }

--- a/src/test/java/com/seventhtill/item/weapon/MeleeWeaponAttackTest.java
+++ b/src/test/java/com/seventhtill/item/weapon/MeleeWeaponAttackTest.java
@@ -13,7 +13,7 @@ class MeleeWeaponAttackTest {
 
         int actualValue = testAttackType.getDamageDie();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -23,6 +23,6 @@ class MeleeWeaponAttackTest {
 
         DamageType actualValue = testAttackType.getDamageType();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 }

--- a/src/test/java/com/seventhtill/item/weapon/RangedWeaponAttackTest.java
+++ b/src/test/java/com/seventhtill/item/weapon/RangedWeaponAttackTest.java
@@ -14,7 +14,7 @@ class RangedWeaponAttackTest {
 
         int actualValue = testAttackType.getDamageDie();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 
     @Test
@@ -24,6 +24,6 @@ class RangedWeaponAttackTest {
 
         DamageType actualValue = testAttackType.getDamageType();
 
-        assert expectedValue == actualValue;
+        assertEquals(expectedValue, actualValue);
     }
 }

--- a/src/test/java/com/seventhtill/item/weapon/SimpleWeaponTest.java
+++ b/src/test/java/com/seventhtill/item/weapon/SimpleWeaponTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 class SimpleWeaponTest {
 
     @Test
@@ -17,7 +19,7 @@ class SimpleWeaponTest {
 
         String actualName = testWeapon.getName();
 
-        assert expectedName.equals(actualName);
+        assertEquals(actualName, expectedName);
     }
 
     @Test
@@ -29,7 +31,7 @@ class SimpleWeaponTest {
 
         int actualWeight = testWeapon.getWeight();
 
-        assert expectedWeight == actualWeight;
+        assertEquals(expectedWeight, actualWeight);
     }
 
     @Test
@@ -43,9 +45,8 @@ class SimpleWeaponTest {
 
         List<String> actualProperties = testWeapon.getProperties();
 
-        assert expectedProperties.equals(actualProperties);
-        assert expectedProperties != actualProperties;
-
+        assertEquals(actualProperties, expectedProperties);
+        assertNotSame(expectedProperties, actualProperties);
     }
 
     @Test
@@ -58,7 +59,7 @@ class SimpleWeaponTest {
         testWeapon.setName(expectedName);
         String actualName = testWeapon.getName();
 
-        assert expectedName.equals(actualName);
+        assertEquals(actualName, expectedName);
     }
 
     @Test
@@ -71,6 +72,6 @@ class SimpleWeaponTest {
         testWeapon.setWeight(expectedWeight);
         int actualWeight = testWeapon.getWeight();
 
-        assert expectedWeight == actualWeight;
+        assertEquals(expectedWeight, actualWeight);
     }
 }


### PR DESCRIPTION
SonarQube raised the use of the `assert` keyword as a blocker. I have rectified this by replacing all of my uses of the assert keyword with JUnit assertion functions in my unit tests.